### PR TITLE
iterable is not available directly on collections

### DIFF
--- a/pyminifier/__init__.py
+++ b/pyminifier/__init__.py
@@ -68,7 +68,7 @@ something is broken.
 # Import built-in modules
 import os, sys, re, io
 from optparse import OptionParser
-from collections import Iterable
+from collections.abc import Iterable
 
 # Import our own modules
 from . import minification


### PR DESCRIPTION
Compatibility for python 3.10 (for being able to use pyminifier in the docker image directly)